### PR TITLE
Change mouse state behaviour when outside of canvas area

### DIFF
--- a/webwindow.py
+++ b/webwindow.py
@@ -186,7 +186,6 @@ script = '''
     });
 
     window.addEventListener('mousedown', (evt) => {
-        const rect = canvas.getBoundingClientRect();
         if (mouseInCanvasBounds(evt)) {
             state.keys.add(mouseKeys[evt.button]);
         }

--- a/webwindow.py
+++ b/webwindow.py
@@ -1,5 +1,5 @@
-import js
-import pyodide
+import js  # type: ignore
+import pyodide  # type: ignore
 
 __version__ = '1.2.1'
 
@@ -19,6 +19,7 @@ script = '''
     document.body.appendChild(backdrop);
 
     const canvas = document.createElement('canvas');
+    canvas.oncontextmenu = () => false;
     canvas.id = 'canvas';
     canvas.tabindex = 1;
     canvas.width = width;
@@ -168,6 +169,18 @@ script = '''
         F24: 'f24',
     };
 
+    const canvasRect = canvas.getBoundingClientRect();
+
+    const mouseInCanvasBounds = (evt) => {
+        if (
+            evt.clientX >= canvasRect.left && evt.clientX <= canvasRect.right 
+            && evt.clientY >= canvasRect.top && evt.clientY <= canvasRect.bottom
+        ) {
+            return true;
+        }
+        return false;
+    }
+
     window.addEventListener('keydown', (evt) => {
         state.keys.add(keys[evt.code]);
     });
@@ -177,7 +190,9 @@ script = '''
     });
 
     window.addEventListener('mousedown', (evt) => {
-        state.keys.add(mouseKeys[evt.button]);
+        if (mouseInCanvasBounds(evt)) {
+            state.keys.add(mouseKeys[evt.button]);
+        }
     });
 
     window.addEventListener('mouseup', (evt) => {
@@ -185,9 +200,13 @@ script = '''
     });
 
     window.addEventListener('mousemove', (evt) => {
-        const rect = canvas.getBoundingClientRect();
-        state.mouse[0] = Math.floor((evt.clientX - rect.left) * canvas.width / rect.width);
-        state.mouse[1] = Math.floor((evt.clientY - rect.top) * canvas.height / rect.height);
+        if (mouseInCanvasBounds(evt)) {
+            state.mouse[0] = Math.floor((evt.clientX - canvasRect.left) * canvas.width / canvasRect.width);
+            state.mouse[1] = Math.floor((evt.clientY - canvasRect.top) * canvas.height / canvasRect.height);
+        }
+        else {
+            state.keys.delete(mouseKeys[evt.button]);
+        }
     });
 
     let last_timestamp = null;

--- a/webwindow.py
+++ b/webwindow.py
@@ -193,7 +193,6 @@ script = '''
     });
 
     window.addEventListener('mouseup', (evt) => {
-        const rect = canvas.getBoundingClientRect();
         state.keys.delete(mouseKeys[evt.button]);
     });
 

--- a/webwindow.py
+++ b/webwindow.py
@@ -203,12 +203,6 @@ script = '''
         }
     });
 
-    canvas.addEventListener('mouseleave', (evt) => {
-        mouseKeys.forEach(key => {
-            state.keys.delete(key);
-        });
-    });
-
     let last_timestamp = null;
     const animate = (timestamp) => {
         if (last_timestamp === null) {

--- a/webwindow.py
+++ b/webwindow.py
@@ -169,16 +169,12 @@ script = '''
         F24: 'f24',
     };
 
-    const canvasRect = canvas.getBoundingClientRect();
-
     const mouseInCanvasBounds = (evt) => {
-        if (
-            evt.clientX >= canvasRect.left && evt.clientX <= canvasRect.right 
-            && evt.clientY >= canvasRect.top && evt.clientY <= canvasRect.bottom
-        ) {
-            return true;
-        }
-        return false;
+        const rect = canvas.getBoundingClientRect();
+        return (
+            evt.clientX >= rect.left && evt.clientX <= rect.right 
+            && evt.clientY >= rect.top && evt.clientY <= rect.bottom
+        );
     }
 
     window.addEventListener('keydown', (evt) => {
@@ -190,23 +186,29 @@ script = '''
     });
 
     window.addEventListener('mousedown', (evt) => {
+        const rect = canvas.getBoundingClientRect();
         if (mouseInCanvasBounds(evt)) {
             state.keys.add(mouseKeys[evt.button]);
         }
     });
 
     window.addEventListener('mouseup', (evt) => {
+        const rect = canvas.getBoundingClientRect();
         state.keys.delete(mouseKeys[evt.button]);
     });
 
     window.addEventListener('mousemove', (evt) => {
+        const rect = canvas.getBoundingClientRect();
         if (mouseInCanvasBounds(evt)) {
-            state.mouse[0] = Math.floor((evt.clientX - canvasRect.left) * canvas.width / canvasRect.width);
-            state.mouse[1] = Math.floor((evt.clientY - canvasRect.top) * canvas.height / canvasRect.height);
+            state.mouse[0] = Math.floor((evt.clientX - rect.left) * canvas.width / rect.width);
+            state.mouse[1] = Math.floor((evt.clientY - rect.top) * canvas.height / rect.height);
         }
-        else {
-            state.keys.delete(mouseKeys[evt.button]);
-        }
+    });
+
+    canvas.addEventListener('mouseleave', (evt) => {
+        mouseKeys.forEach(key => {
+            state.keys.delete(key);
+        });
     });
 
     let last_timestamp = null;


### PR DESCRIPTION
Change the following behaviour as discussed in [this issue](https://github.com/szabolcsdombi/webwindow/issues/1):

1) Disable context menu opening when right-clicking within the canvas area

2) Disable click events registering when mouse is outside of the canvas area

3) Clear mouse buttons state and retain last position state when mouse leaves the canvas area

Also add # type: ignore on the imports to keep linter/mypy happy.

Let me know if you'd like any changes & whether to bump the version (patch/minor?)